### PR TITLE
fix: ROS2 Humble. Parameter {r_max} is of type {double}.

### DIFF
--- a/linefit_ground_segmentation_ros/launch/segmentation_params.yaml
+++ b/linefit_ground_segmentation_ros/launch/segmentation_params.yaml
@@ -3,7 +3,7 @@ ground_segmentation:
     n_threads: 4                # number of threads to use.
 
     r_min: 0.2                  # minimum point distance.
-    r_max: 50                   # maximum point distance.
+    r_max: 50.0                 # maximum point distance.
     n_bins: 120                 # number of radial bins.
     n_segments: 360             # number of radial segments.
 


### PR DESCRIPTION
Closes #2